### PR TITLE
new/create

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,9 +1,31 @@
 class ActivitiesController < ApplicationController
     def index
       @activities = Activity.all.order(:title)
+      #@activities = @activities.where(:approval_status = "Approved") this syntax very likely wrong
     end
 
     def show
       @activity = Activity.find(params[:id])
+    end
+
+    def new
+      @activity = Activity.new()
+    end
+
+    def create
+      @activity = Activity.new(create_params)
+      @activity.approval_status = 1
+      if @activity.save
+        flash[:notice] = "Activity #{@activity.title} proposed!"
+        redirect_to activities_path
+      else
+        flash[:alert] = "Cannot propose activity :("
+        render :new, status: :unprocessable_content
+      end
+    end
+
+    private
+    def create_params
+      params.require(:activity).permit(:title, :description, :spots, :chaperone, :approval_status, :day, :time_start, :time_end)
     end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,4 +1,15 @@
 class Activity < ApplicationRecord
+
+    validates :title, presence: true
+    validates :description, presence: true
+    validates :spots, presence: true, numericality: {greater_than_or_equal_to: 1, less_than_or_equal_to: 35}
+    validates :chaperone, presence: true
+    validates :time_start, presence: true
+    validates :time_end, presence: true 
+    validates :time_end, comparison: {greater_than: :time_start}
+
+
     enum :day, %i[Monday Tuesday Wednesday Thursday Friday]
+    enum :approval_status, %i[Approved Pending Denied]
 
 end

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -19,5 +19,9 @@
       <% end %>
     </div>
 
+    
+    <%= link_to "Propose an Actvity!", new_activity_path, class: "btn btn-info" %>
+    
+
 
 </div>

--- a/app/views/activities/new.html.erb
+++ b/app/views/activities/new.html.erb
@@ -1,0 +1,44 @@
+<div class="container">
+  <div class="row">
+    <h1>Propose Activity</h1>
+  </div>
+
+  <%= form_with model: @activity, method: :post do |f| %>
+    <div class="form-group">
+      <%= f.label :title %>
+      <%= f.text_field :title, class: 'form-control' %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :description %>
+      <%= f.text_area :description, class: 'form-control' %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :spots %>
+      <%= f.number_field :spots, min: 1, max: 35, step: 1, class: 'form-control' %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :chaperone %>
+      <%= f.text_field :chaperone, class: 'form-control' %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :day %>
+      <%= f.select :day, Activity.days.keys.map { |w| [w.humanize, w] }, {}, class: 'form-control' %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :time_start %>
+      <%= f.time_select :time_Start, include_seconds: false %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :time_end %>
+      <%= f.time_select :time_end, include_seconds: false %>
+    </div>
+
+    <%= f.submit class: 'btn btn-primary' %>
+  <% end %>
+</div>

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -3,3 +3,31 @@ require 'rails_helper'
 RSpec.describe Activity, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end
+
+describe "create new activity" do
+  it "should show the new form" do
+    visit activities_path
+    click_on "Propose an Activity!"
+    expect(page.text).to eq(/Propose Activity/)
+  end
+  it "should re-render the page with error message if save fails" do
+    visit new_activity_path
+    click_on "Propose Activity"
+    expect(page.current_path).to eq(new_activity_path)
+    expect(page.text).to match /Cannot propose activity/
+  end
+  it 'should create successfully' do
+    visit new_activity_path
+    fill_in 'Title', with: 'test act'
+    fill_in 'Description', with: 'desc test'
+    fill_in 'Spots', with: 10
+    fill_in 'Chaperone', with: 'm. test'
+    fill_in 'day', with: 'Monday'
+    select_time('3', '00', from: 'Open time')
+    select_time('4', '00', from: 'Close time')
+    click_on 'Create Sight'
+    expect(page).to have_content('Activity test act proposed')
+    expect(page.current_path).to eq(activities_path)
+    expect(page).to have_content('test act') #will need to change this since it won't be visible due to status
+  end
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -4,30 +4,3 @@ RSpec.describe Activity, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end
 
-describe "create new activity" do
-  it "should show the new form" do
-    visit activities_path
-    click_on "Propose an Activity!"
-    expect(page.text).to eq(/Propose Activity/)
-  end
-  it "should re-render the page with error message if save fails" do
-    visit new_activity_path
-    click_on "Propose Activity"
-    expect(page.current_path).to eq(new_activity_path)
-    expect(page.text).to match /Cannot propose activity/
-  end
-  it 'should create successfully' do
-    visit new_activity_path
-    fill_in 'Title', with: 'test act'
-    fill_in 'Description', with: 'desc test'
-    fill_in 'Spots', with: 10
-    fill_in 'Chaperone', with: 'm. test'
-    fill_in 'day', with: 'Monday'
-    select_time('3', '00', from: 'Open time')
-    select_time('4', '00', from: 'Close time')
-    click_on 'Create Sight'
-    expect(page).to have_content('Activity test act proposed')
-    expect(page.current_path).to eq(activities_path)
-    expect(page).to have_content('test act') #will need to change this since it won't be visible due to status
-  end
-end

--- a/spec/models/new_spec.erb
+++ b/spec/models/new_spec.erb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe "new", type: :system do
+    before do
+      driven_by(:rack_test)
+    end
+
+    describe "create new activity" do
+        it "should show the new form from index page button" do
+            visit activities_path
+            click_on "Propose an Activity!"
+            expect(page.current_path).to eq(new_activity_path)
+            expect(page.text).to eq(/Propose Activity/)
+        end
+        it "should re-render the page with error message if save fails" do
+            visit new_activity_path
+            click_on "Propose Activity"
+            expect(page.current_path).to eq(new_activity_path)
+            expect(page.text).to match /Cannot propose activity/
+        end
+        it 'should create successfully' do
+            visit new_activity_path
+            fill_in 'Title', with: 'test act'
+            fill_in 'Description', with: 'desc test'
+            fill_in 'Spots', with: 10
+            fill_in 'Chaperone', with: 'm. test'
+            fill_in 'day', with: 'Monday'
+            select_time('3', '00', from: 'Open time')
+            select_time('4', '00', from: 'Close time')
+            click_on 'Create Sight'
+            expect(page).to have_content('Activity test act proposed')
+            expect(page.current_path).to eq(activities_path)
+            expect(page).to have_content('test act') #will need to change this since it won't be visible due to status
+        end
+    end
+end


### PR DESCRIPTION
there is a new activity page, it can create a new instance, and has some tests. none of the tests work due to them not recognizing the paths for reasons i'm not totally clear on. i added an enumeration thing for approval status to activtity.rb and so it requires every field but approval status, which should be set automatically to pending now in the controller. also a new 'propose activity' button on index view. there is a new activity that i made to test it and i didn't make a destroy so it's just there. also i did like no formatting currently